### PR TITLE
HRTH-35 dms group chats

### DIFF
--- a/client/src/app/api/realms/[realmId]/rooms/route.ts
+++ b/client/src/app/api/realms/[realmId]/rooms/route.ts
@@ -109,7 +109,7 @@ const patchBodySchema = z.object({
 	roomScope: z.nativeEnum(RoomScope),
 	roomType: z.nativeEnum(RoomType),
 	roomIconUrl: z.string().nullable(),
-	roomDescription: z.string(),
+	roomDescription: z.string().nullable(),
 	isAgeRestricted: z.boolean()
 });
 

--- a/client/src/app/api/realms/route.ts
+++ b/client/src/app/api/realms/route.ts
@@ -24,9 +24,15 @@ const GET = withApiAuthRequired(async (req: NextRequest) => {
 			},
 			include: {
 				UsersOnRealms: {
-					where: {
-						auth0Id: userAuth0Id
-					},
+					include: {
+						user: {
+							select: {
+								avatarUrl: true,
+								displayName: true,
+							}
+						},
+						FactionsOnUsersOnRealms: true
+					}
 				}
 			}
 		});

--- a/client/src/app/api/rooms/route.ts
+++ b/client/src/app/api/rooms/route.ts
@@ -481,7 +481,7 @@ const PATCH = withApiAuthRequired(async (req: NextRequest) => {
 			return NextResponse.json({ success: false, message: authorizationResult.message }, { status: authorizationResult.status });
 		}
 
-		if (![isFavorited, hasLeft].find(param => param !== undefined)) {
+		if ([isFavorited, hasLeft].every(param => param === undefined)) {
 			return NextResponse.json({ success: false, message: "No argument values provided for patch" }, { status: 400 });
 		}
 

--- a/client/src/components/dashboard/Dashboard.tsx
+++ b/client/src/components/dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
 "use client"
 import ChatRoomContainer from "./ChatRoomContainer";
 import InboxesContainer from "./InboxesContainer";
+import MembersList from "./MembersList";
 import PersonalContainer from "./me/PersonalContainer";
 import SideBar from "./side/SideBar";
 import { RealmProvider } from "@/context/RealmContext";
@@ -37,7 +38,8 @@ const Dashboard = ({ showDirectMessages }: DashboardProps) => {
 							</div>
 
 							{/* Right edge profile info */}
-							<div className="bg-slate-200 dark:bg-slate-900 sm:w-[300px] sm:h-[100%]">
+							<div className="bg-slate-200 dark:bg-slate-900 sm:w-[200px] sm:h-[100%]">
+								<MembersList />
 							</div>
 						</div>
 					</RoomProvider>

--- a/client/src/components/dashboard/Dashboard.tsx
+++ b/client/src/components/dashboard/Dashboard.tsx
@@ -38,7 +38,7 @@ const Dashboard = ({ showDirectMessages }: DashboardProps) => {
 							</div>
 
 							{/* Right edge profile info */}
-							<div className="bg-slate-200 dark:bg-slate-900 sm:w-[200px] sm:h-[100%]">
+							<div className="bg-slate-200 dark:bg-slate-900 sm:w-[200px] sm:inline hidden sm:h-[100%]">
 								<MembersList />
 							</div>
 						</div>

--- a/client/src/components/dashboard/InboxesContainer.tsx
+++ b/client/src/components/dashboard/InboxesContainer.tsx
@@ -3,7 +3,7 @@ import Domains from "../features/domains/Domains";
 
 const InboxesContainer = () => {
 	return (
-		<div className="flex flex-col h-[100%] sm:w-[240px] pb-4">
+		<div className="flex flex-col h-[100%] sm:w-[240px] pb-4 pt-3">
 			<PatchRealm />
 			<Domains />
 		</div>

--- a/client/src/components/dashboard/MembersList.tsx
+++ b/client/src/components/dashboard/MembersList.tsx
@@ -5,36 +5,61 @@ import CollapsableHeading from "../ui/CollapsableHeading";
 import { ADMIN_LEVELS } from "@/util/auth";
 import { FaCrown } from "react-icons/fa6";
 import { UsersOnRealmsLevels } from "@prisma/client";
+import { Dropdown } from "../ui/Dropdown";
+import { RealmDropdownContent } from "./SentMessages";
+import { useUser } from "@auth0/nextjs-auth0/client";
 
 interface MembersListProps {
 	displayName: string;
 	avatarUrl: string;
+	userId: string;
 	isOwner?: boolean;
 }
 
-const MembersListItem = ({ displayName, avatarUrl, isOwner = false }: MembersListProps) => {
-	return (
-		<div className={`group hover:dark:bg-slate-800 hover:bg-slate-300 hover:cursor-pointer rounded-md flex`}
-			title={displayName}>
-			<div className="z-10 p-1 flex h-[45px] my-1 flex-shrink flex-grow min-w-0 w-full"
-			>
-				<Image
-					className="rounded-full max-h-[35px] min-w-[35px] my-auto"
-					alt="Picture"
-					src={avatarUrl || "/favicon\.ico"}
-					width={35}
-					height={35} />
-				<div className="ml-1 overflow-x-hidden whitespace-nowrap text-ellipsis self-center">
-					{displayName}
+const MembersListItem = ({ displayName, avatarUrl, userId, isOwner = false }: MembersListProps) => {
+	const { user } = useUser();
+
+	const ItemContent = () => {
+		return (
+			<div className={`group hover:dark:bg-slate-800 hover:bg-slate-300 hover:cursor-pointer rounded-md flex`}
+				title={displayName}>
+				<div className="z-10 p-1 flex h-[45px] my-1 flex-shrink flex-grow min-w-0 w-full"
+				>
+					<Image
+						className="rounded-full max-h-[35px] min-w-[35px] my-auto"
+						alt="Picture"
+						src={avatarUrl || "/favicon\.ico"}
+						width={35}
+						height={35} />
+					<div className="ml-1 overflow-x-hidden whitespace-nowrap text-ellipsis self-center">
+						{displayName}
+					</div>
+					{isOwner &&
+						<div className="self-center ml-1 p-1 dark:text-amber-400 text-amber-500"
+							title="Realm Owner"
+						>
+							<FaCrown />
+						</div>}
 				</div>
-				{isOwner &&
-					<div className="self-center ml-1 p-1 dark:text-amber-400 text-amber-500"
-						title="Realm Owner"
-					>
-						<FaCrown />
-					</div>}
 			</div>
-		</div>
+		);
+	}
+
+	if (!user) return (<></>);
+
+	return (
+		<>
+			{user.sub !== userId ?
+				<Dropdown
+					openingNode={
+						< ItemContent />
+					}
+				>
+					<RealmDropdownContent displayName={displayName} userId={userId} />
+				</Dropdown > :
+				<ItemContent />}
+		</>
+
 	);
 }
 
@@ -54,6 +79,7 @@ const MembersList = () => {
 							key={userOnRealm.userOnRealmId}
 							displayName={userOnRealm.user.displayName}
 							avatarUrl={userOnRealm.user.avatarUrl}
+							userId={userOnRealm.auth0Id}
 							isOwner={userOnRealm.memberLevel === UsersOnRealmsLevels.OWNER} />
 					))}
 			</CollapsableHeading>
@@ -65,7 +91,8 @@ const MembersList = () => {
 						<MembersListItem
 							key={userOnRealm.userOnRealmId}
 							displayName={userOnRealm.user.displayName}
-							avatarUrl={userOnRealm.user.avatarUrl} />
+							avatarUrl={userOnRealm.user.avatarUrl}
+							userId={userOnRealm.auth0Id} />
 					))}
 			</CollapsableHeading>
 		</div>

--- a/client/src/components/dashboard/MembersList.tsx
+++ b/client/src/components/dashboard/MembersList.tsx
@@ -1,0 +1,75 @@
+import RealmContext from "@/context/RealmContext";
+import Image from "next/image";
+import { useContext } from "react";
+import CollapsableHeading from "../ui/CollapsableHeading";
+import { ADMIN_LEVELS } from "@/util/auth";
+import { FaCrown } from "react-icons/fa6";
+import { UsersOnRealmsLevels } from "@prisma/client";
+
+interface MembersListProps {
+	displayName: string;
+	avatarUrl: string;
+	isOwner?: boolean;
+}
+
+const MembersListItem = ({ displayName, avatarUrl, isOwner = false }: MembersListProps) => {
+	return (
+		<div className={`group hover:dark:bg-slate-800 hover:bg-slate-300 hover:cursor-pointer rounded-md flex`}
+			title={displayName}>
+			<div className="z-10 p-1 flex h-[45px] my-1 flex-shrink flex-grow min-w-0 w-full"
+			>
+				<Image
+					className="rounded-full max-h-[35px] min-w-[35px] my-auto"
+					alt="Picture"
+					src={avatarUrl || "/favicon\.ico"}
+					width={35}
+					height={35} />
+				<div className="ml-1 overflow-x-hidden whitespace-nowrap text-ellipsis self-center">
+					{displayName}
+				</div>
+				{isOwner &&
+					<div className="self-center ml-1 p-1 dark:text-amber-400 text-amber-500"
+						title="Realm Owner"
+					>
+						<FaCrown />
+					</div>}
+			</div>
+		</div>
+	);
+}
+
+const MembersList = () => {
+	const [activeRealm] = useContext(RealmContext);
+
+	if (activeRealm === null) return (<></>);
+
+	return (
+		<div className="px-2 w-[200px] mt-3">
+			<CollapsableHeading heading="Admins">
+				{activeRealm.UsersOnRealms
+					.filter((userOnRealm) => (
+						(ADMIN_LEVELS.includes(userOnRealm.memberLevel))
+					)).map((userOnRealm) => (
+						<MembersListItem
+							key={userOnRealm.userOnRealmId}
+							displayName={userOnRealm.user.displayName}
+							avatarUrl={userOnRealm.user.avatarUrl}
+							isOwner={userOnRealm.memberLevel === UsersOnRealmsLevels.OWNER} />
+					))}
+			</CollapsableHeading>
+			<CollapsableHeading heading="Members">
+				{activeRealm.UsersOnRealms
+					.filter((userOnRealm) => (
+						!(ADMIN_LEVELS.includes(userOnRealm.memberLevel))
+					)).map((userOnRealm) => (
+						<MembersListItem
+							key={userOnRealm.userOnRealmId}
+							displayName={userOnRealm.user.displayName}
+							avatarUrl={userOnRealm.user.avatarUrl} />
+					))}
+			</CollapsableHeading>
+		</div>
+	);
+}
+
+export default MembersList;

--- a/client/src/components/dashboard/SentMessages.tsx
+++ b/client/src/components/dashboard/SentMessages.tsx
@@ -28,66 +28,69 @@ const ProfilePicture = ({ avatarUrl, minWidth }: { avatarUrl: string, minWidth?:
 	);
 }
 
+const PrivateChatDropdownContent = () => {
+	return (
+		<>
+		</>
+	);
+}
+
+interface RealmDropDownContentProps {
+	displayName: string;
+	userId: string
+}
+
+export const RealmDropdownContent = ({ displayName, userId }: RealmDropDownContentProps) => {
+	const router = useRouter();
+
+	const handleOpenDirectMessage = () => {
+		axios.put(`/api/dm/${encodeURIComponent(userId)}`)
+			.then(async (res) => {
+				const { roomId, detailedRoom } = res.data;
+				await mutate("/api/rooms",
+					(currData: UserDetailedDirectRoomResponse | undefined) => {
+						if (!currData?.success || !currData?.rooms) return currData;
+						const updatedRooms: UserDetailedDirectRoom[] = [detailedRoom, ...currData.rooms];
+						console.log(updatedRooms);
+						return {
+							...currData,
+							rooms: updatedRooms
+						};
+					}, false);
+				router.push(`/dashboard/me/${roomId}`);
+			})
+			.catch((e) => console.error(e));
+	}
+
+	return (
+		<>
+			<DropdownListCategory>
+				<DropdownListItem
+					icon={<FaMessage />}
+					intrinsicProps={{
+						title: "Open Direct Message",
+						onClick: handleOpenDirectMessage
+					}}
+				>
+					Message <span className="dark:text-slate-400 text-slate-600">{displayName}</span>
+				</DropdownListItem>
+			</DropdownListCategory>
+			<DropdownCategoryDivider />
+			<DropdownListCategory>
+				<DropdownListItem icon={<FaX />}>Remove From Realm</DropdownListItem>
+			</DropdownListCategory>
+		</>
+	);
+}
+
 const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageForView, viewingUserId: string }) => {
 	const sharedClasses = "whitespace-pre w-fit flex-wrap text-wrap rounded-xl px-3 py-2 mb-2 mt-1 break-all"
 
 	const localTime = message.time && new Date(message.time).toLocaleTimeString();
 
-	const [activeRoom, setActiveRoom] = useContext(RoomContext);
+	const [activeRoom] = useContext(RoomContext);
 
 	if (activeRoom === null) return <></>;
-
-	const PrivateChatDropdownContent = () => {
-		return (
-			<>
-			</>
-		);
-	}
-
-	const RealmDropdownContent = () => {
-		const router = useRouter();
-
-		const handleOpenDirectMessage = () => {
-			if (setActiveRoom === undefined) return;
-			axios.put(`/api/dm/${encodeURIComponent(message.userId)}`)
-				.then(async (res) => {
-					const { roomId, detailedRoom } = res.data;
-					await mutate("/api/rooms",
-						(currData: UserDetailedDirectRoomResponse | undefined) => {
-							if (!currData?.success || !currData?.rooms) return currData;
-							const updatedRooms: UserDetailedDirectRoom[] = [detailedRoom, ...currData.rooms];
-							console.log(updatedRooms);
-							return {
-								...currData,
-								rooms: updatedRooms
-							};
-						}, false);
-					// setActiveRoom(detailedRoom.roomId);
-					router.push(`/dashboard/me/${roomId}`);
-				})
-				.catch((e) => console.error(e));
-		}
-
-		return (
-			<>
-				<DropdownListCategory>
-					<DropdownListItem
-						icon={<FaMessage />}
-						intrinsicProps={{
-							title: "Open Direct Message",
-							onClick: handleOpenDirectMessage
-						}}
-					>
-						Message <span className="dark:text-slate-400 text-slate-600">{message.displayName}</span>
-					</DropdownListItem>
-				</DropdownListCategory>
-				<DropdownCategoryDivider />
-				<DropdownListCategory>
-					<DropdownListItem icon={<FaX />}>Remove From Realm</DropdownListItem>
-				</DropdownListCategory>
-			</>
-		);
-	}
 
 	return (
 		<>
@@ -111,7 +114,7 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 								}
 							>
 								{activeRoom.roomScope === RoomScope.REALM ?
-									<RealmDropdownContent /> :
+									<RealmDropdownContent displayName={message.displayName} userId={message.userId} /> :
 									<PrivateChatDropdownContent />}
 							</Dropdown>
 							<div>

--- a/client/src/components/dashboard/SentMessages.tsx
+++ b/client/src/components/dashboard/SentMessages.tsx
@@ -50,8 +50,8 @@ export const RealmDropdownContent = ({ displayName, userId }: RealmDropDownConte
 				await mutate("/api/rooms",
 					(currData: UserDetailedDirectRoomResponse | undefined) => {
 						if (!currData?.success || !currData?.rooms) return currData;
-						const updatedRooms: UserDetailedDirectRoom[] = [detailedRoom, ...currData.rooms];
-						console.log(updatedRooms);
+						const updatedRooms: UserDetailedDirectRoom[] = [detailedRoom, ...currData.rooms
+							.filter((room) => room.roomId !== detailedRoom.roomId)];
 						return {
 							...currData,
 							rooms: updatedRooms

--- a/client/src/components/dashboard/SentMessages.tsx
+++ b/client/src/components/dashboard/SentMessages.tsx
@@ -89,7 +89,6 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 
 	return (
 		<>
-			<p className={message.userId === loggedInUserId ? "text-right" : ""}>{message.displayName}:</p>
 			{
 				message.userId === loggedInUserId ?
 					<div className="flex flex-row-reverse">
@@ -97,7 +96,7 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 							<ProfilePicture avatarUrl={message.avatarUrl} minWidth={50} />
 							<div>
 								<p className={`${sharedClasses} bg-gradient-to-tl dark:from-purple-700 dark:to-red-500 from-purple-400 to-red-200 rounded-tr-none mr-2`}>{message.content}</p>
-								<p className={`text-xs text-slate-400`}>{localTime}</p>
+								<p className={`text-xs text-slate-400 text-right`}>{localTime}</p>
 							</div>
 						</div>
 					</div>
@@ -114,8 +113,10 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 									<PrivateChatDropdownContent />}
 							</Dropdown>
 							<div>
-								<p className={`${sharedClasses} bg-gradient-to-tl dark:from-red-600 dark:to-yellow-500 from-red-300 to-yellow-200 rounded-tl-none ml-2`}>{message.content}</p>
-								<p className={`text-xs text-slate-400 flex flex-row-reverse`}>{localTime}</p>
+								<p className={`${sharedClasses} bg-gradient-to-tl dark:from-red-600 dark:to-yellow-500 from-red-300 to-yellow-200 rounded-tl-none ml-2`}>
+									<div className="font-bold text-left text-slate-500 dark:text-slate-50">{message.displayName}</div>{message.content}
+								</p>
+								<p className={`text-xs text-slate-400 flex ml-2`}>{localTime}</p>
 							</div>
 						</div>
 					</div>
@@ -134,7 +135,7 @@ const SentMessages = ({ messages }: { messages: MessageForView[] }) => {
 	}
 
 	return (
-		<div className="px-2 mt-auto w-full">
+		<div className="px-2 mt-auto w-full flex flex-col gap-2">
 			{messages.map((message, index) => {
 				return (
 					<div key={index}

--- a/client/src/components/dashboard/SentMessages.tsx
+++ b/client/src/components/dashboard/SentMessages.tsx
@@ -33,7 +33,7 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 
 	const localTime = message.time && new Date(message.time).toLocaleTimeString();
 
-	const [activeRoom] = useContext(RoomContext);
+	const [activeRoom, setActiveRoom] = useContext(RoomContext);
 
 	if (activeRoom === null) return <></>;
 
@@ -48,19 +48,21 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 		const router = useRouter();
 
 		const handleOpenDirectMessage = () => {
+			if (setActiveRoom === undefined) return;
 			axios.put(`/api/dm/${encodeURIComponent(message.userId)}`)
-				.then((res) => {
+				.then(async (res) => {
 					const { roomId, detailedRoom } = res.data;
-					mutate("/api/rooms",
-						((currData: UserDetailedDirectRoomResponse | undefined) => {
+					await mutate("/api/rooms",
+						(currData: UserDetailedDirectRoomResponse | undefined) => {
 							if (!currData?.success || !currData?.rooms) return currData;
 							const updatedRooms: UserDetailedDirectRoom[] = [detailedRoom, ...currData.rooms];
-
+							console.log(updatedRooms);
 							return {
 								...currData,
 								rooms: updatedRooms
 							};
-						}), false);
+						}, false);
+					// setActiveRoom(detailedRoom.roomId);
 					router.push(`/dashboard/me/${roomId}`);
 				})
 				.catch((e) => console.error(e));
@@ -95,7 +97,7 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 						<div className="flex flex-row-reverse max-w-[85%]">
 							<ProfilePicture avatarUrl={message.avatarUrl} minWidth={50} />
 							<div>
-								<p className={`${sharedClasses} bg-gradient-to-tl dark:from-purple-700 dark:to-red-500 from-purple-400 to-red-200 rounded-tr-none mr-2`}>{message.content}</p>
+								<div className={`${sharedClasses} bg-gradient-to-tl dark:from-purple-700 dark:to-red-500 from-purple-400 to-red-200 rounded-tr-none mr-2`}>{message.content}</div>
 								<p className={`text-xs text-slate-400 text-right`}>{localTime}</p>
 							</div>
 						</div>
@@ -113,9 +115,9 @@ const Message = ({ message, viewingUserId: loggedInUserId }: { message: MessageF
 									<PrivateChatDropdownContent />}
 							</Dropdown>
 							<div>
-								<p className={`${sharedClasses} bg-gradient-to-tl dark:from-red-600 dark:to-yellow-500 from-red-300 to-yellow-200 rounded-tl-none ml-2`}>
+								<div className={`${sharedClasses} bg-gradient-to-tl dark:from-red-600 dark:to-yellow-500 from-red-300 to-yellow-200 rounded-tl-none ml-2`}>
 									<div className="font-bold text-left text-slate-500 dark:text-slate-50">{message.displayName}</div>{message.content}
-								</p>
+								</div>
 								<p className={`text-xs text-slate-400 flex ml-2`}>{localTime}</p>
 							</div>
 						</div>

--- a/client/src/components/dashboard/me/PersonalContainer.tsx
+++ b/client/src/components/dashboard/me/PersonalContainer.tsx
@@ -129,7 +129,7 @@ const Star = ({ room }: StarProps) => {
 	}
 
 	return (
-		<div className="z-20 absolute translate-y-1 translate-x-1 hidden group-hover:inline-block"
+		<div className="z-20 absolute translate-y-2 hidden group-hover:inline-block p-1"
 			onClick={handleStarClicked}>
 			{room.requestingUserInRoom?.isFavorited ?
 				<FaStar className="dark:text-amber-400 text-amber-500" title="Unstar" /> :

--- a/client/src/components/dashboard/me/PersonalContainer.tsx
+++ b/client/src/components/dashboard/me/PersonalContainer.tsx
@@ -1,4 +1,5 @@
 import { UserDetailedDirectRoom, UserDetailedDirectRoomResponse } from "@/app/api/rooms/route";
+import CollapsableHeading from "@/components/ui/CollapsableHeading";
 import { Dropdown, DropdownCategoryDivider, DropdownListCategory, DropdownListItem } from "@/components/ui/Dropdown";
 import RoomContext from "@/context/RoomContext";
 import { useUser } from "@auth0/nextjs-auth0/client";
@@ -7,31 +8,10 @@ import axios from "axios";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { ReactNode, useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { FaUserFriends } from "react-icons/fa";
-import { FaAngleDown, FaAngleRight, FaArrowLeft, FaClipboard, FaRegStar, FaStar } from "react-icons/fa6";
+import { FaArrowLeft, FaClipboard, FaRegStar, FaStar } from "react-icons/fa6";
 import useSWR, { mutate } from "swr";
-
-const CollapsableHeading = ({ heading, children }: { heading: string, children?: ReactNode }) => {
-	const [showing, setShowing] = useState(true);
-
-	return (
-		<>
-			<div
-				className="hover:cursor-pointer hover:dark:brightness-90 w-full overflow-hidden flex mt-8"
-				onClick={() => { setShowing(curr => !curr) }}
-			>
-				<div className="pr-1">
-					{showing ? <FaAngleDown /> : <FaAngleRight />}
-				</div>
-				<div className="font-bold text-xs dark:text-slate-400 text-slate-500 overflow-hidden text-ellipsis whitespace-nowrap">
-					{heading}
-				</div>
-			</div>
-			{showing && children}
-		</>
-	);
-}
 
 interface GroupChatImageProps {
 	roomIconUrl: string | null;

--- a/client/src/components/dashboard/side/Realms.tsx
+++ b/client/src/components/dashboard/side/Realms.tsx
@@ -1,7 +1,6 @@
 "use client"
 import PersonalChatOpener from "@/components/features/dm/PersonalChatOpener";
-import RealmContext from "@/context/RealmContext";
-import { UsersOnRealms, Realm } from "@prisma/client";
+import RealmContext, { RealmWithAuth } from "@/context/RealmContext";
 import axios from "axios";
 import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
@@ -26,13 +25,9 @@ const Realms = ({ selectedDMs }: RealmsProps) => {
 		dedupingInterval: 60000,
 	});
 
-	const defaultRealms = data ? data.realms as ({
-		UsersOnRealms: UsersOnRealms[];
-	} & Realm)[] : []
+	const defaultRealms = data ? data.realms as RealmWithAuth[] : []
 
-	const [realms, setRealms] = useState<({
-		UsersOnRealms: UsersOnRealms[];
-	} & Realm)[]>(defaultRealms);
+	const [realms, setRealms] = useState<RealmWithAuth[]>(defaultRealms);
 
 	const [activeRealm, setActiveRealm] = useContext(RealmContext);
 

--- a/client/src/components/features/rooms/Room.tsx
+++ b/client/src/components/features/rooms/Room.tsx
@@ -24,9 +24,10 @@ interface RoomProps {
 	room: Room;
 	selected: boolean;
 	domains: OptionallyParentalDomain[];
+	showAdmin: boolean;
 }
 
-const RoomItem = ({ room, selected, domains }: RoomProps) => {
+const RoomItem = ({ room, selected, domains, showAdmin }: RoomProps) => {
 	const [activeRoom, setActiveRoom] = useContext(RoomContext);
 
 	const bg = selected ?
@@ -43,10 +44,11 @@ const RoomItem = ({ room, selected, domains }: RoomProps) => {
 			}}>
 			<RoomIcon roomType={room.roomType} />
 			<div className="w-full overflow-hidden text-ellipsis text-nowrap">{room.roomName}</div>
-			<div className="hidden group-hover:flex ml-auto self-center">
-				<PatchRoom room={room} domains={domains} />
-				<DeleteRoom roomId={room.roomId} roomName={room.roomName} />
-			</div>
+			{showAdmin &&
+				<div className="hidden group-hover:flex ml-auto self-center">
+					<PatchRoom room={room} domains={domains} />
+					<DeleteRoom roomId={room.roomId} roomName={room.roomName} />
+				</div>}
 		</div>
 	);
 }

--- a/client/src/components/ui/CollapsableHeading.tsx
+++ b/client/src/components/ui/CollapsableHeading.tsx
@@ -1,0 +1,25 @@
+import { ReactNode, useState } from "react";
+import { FaAngleDown, FaAngleRight } from "react-icons/fa";
+
+const CollapsableHeading = ({ heading, children }: { heading: string, children?: ReactNode }) => {
+	const [showing, setShowing] = useState(true);
+
+	return (
+		<>
+			<div
+				className="hover:cursor-pointer hover:dark:brightness-90 w-full overflow-hidden flex mt-8"
+				onClick={() => { setShowing(curr => !curr) }}
+			>
+				<div className="pr-1">
+					{showing ? <FaAngleDown /> : <FaAngleRight />}
+				</div>
+				<div className="font-bold text-xs dark:text-slate-400 text-slate-500 overflow-hidden text-ellipsis whitespace-nowrap">
+					{heading}
+				</div>
+			</div>
+			{showing && children}
+		</>
+	);
+}
+
+export default CollapsableHeading;

--- a/client/src/context/RealmContext.tsx
+++ b/client/src/context/RealmContext.tsx
@@ -13,7 +13,6 @@ export type RealmWithAuth = {
 	UsersOnRealms: DetailedUsersOnRealms[];
 } & Realm
 
-// Sends the Id of the active realm if one is chosen otherwise undefined
 const RealmContext = createContext<[
 	RealmWithAuth | null,
 	Dispatch<SetStateAction<RealmWithAuth | null>> | undefined]>([null, undefined]);

--- a/client/src/context/RealmContext.tsx
+++ b/client/src/context/RealmContext.tsx
@@ -9,7 +9,7 @@ type DetailedUsersOnRealms = UsersOnRealms & {
 	}
 } & FactionsOnUsersOnRealms;
 
-type RealmWithAuth = {
+export type RealmWithAuth = {
 	UsersOnRealms: DetailedUsersOnRealms[];
 } & Realm
 

--- a/client/src/context/RealmContext.tsx
+++ b/client/src/context/RealmContext.tsx
@@ -1,9 +1,16 @@
 "use client"
-import { Realm, UsersOnRealms } from "@prisma/client";
+import { FactionsOnUsersOnRealms, Realm, UsersOnRealms } from "@prisma/client";
 import { createContext, Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
 
+type DetailedUsersOnRealms = UsersOnRealms & {
+	user: {
+		avatarUrl: string,
+		displayName: string,
+	}
+} & FactionsOnUsersOnRealms;
+
 type RealmWithAuth = {
-	UsersOnRealms: UsersOnRealms[];
+	UsersOnRealms: DetailedUsersOnRealms[];
 } & Realm
 
 // Sends the Id of the active realm if one is chosen otherwise undefined

--- a/client/src/util/auth.ts
+++ b/client/src/util/auth.ts
@@ -57,9 +57,9 @@ export const checkUserAuthentication = async (req: NextRequest): Promise<Authent
 	return { authenticated: true, userAuth0Id: userAuth0Id }
 }
 
-export const OWNER_LEVELS = [UsersOnRealmsLevels.OWNER];
-export const ADMIN_LEVELS = [...OWNER_LEVELS, UsersOnRealmsLevels.ADMIN];
-export const MEMBER_LEVELS = [...ADMIN_LEVELS, UsersOnRealmsLevels.MEMBER];
+export const OWNER_LEVELS: UsersOnRealmsLevels[] = [UsersOnRealmsLevels.OWNER];
+export const ADMIN_LEVELS: UsersOnRealmsLevels[] = [...OWNER_LEVELS, UsersOnRealmsLevels.ADMIN];
+export const MEMBER_LEVELS: UsersOnRealmsLevels[] = [...ADMIN_LEVELS, UsersOnRealmsLevels.MEMBER];
 
 interface RealmAuthorizationError {
 	authorized: false;


### PR DESCRIPTION
## Adds:
- realm member lists panel content
- redesigned message bubbles for sent and received messages
- user ability to remove DMs/GCs from their personal messages panel
  - DMs can be rejoined by interacting with the other user's profile

## Fixes:
- exported a once-redeclared type definition for the realm data used in context
- fixed Zod schema on patch room requiring a non-null description (different to the postgres requirement)
- removed admin options for member-level users on realms